### PR TITLE
Please make the logging level user-configurable

### DIFF
--- a/build/jslib/build.js
+++ b/build/jslib/build.js
@@ -130,6 +130,10 @@ function (lang,   logger,   file,          parse,    optimize,   pragma,
         config = build.createConfig(cmdConfig);
         paths = config.paths;
 
+        if ( config.logLevel ) {
+            logger.logLevel( config.logLevel );
+        }
+
         if (!config.out && !config.cssIn) {
             //This is not just a one-off file build but a full build profile, with
             //lots of files to process.

--- a/build/jslib/logger.js
+++ b/build/jslib/logger.js
@@ -16,6 +16,10 @@ define(['env!env/print'], function (print) {
         level: 0,
         logPrefix: "",
 
+        logLevel: function( level ) {
+            this.level = level;
+        },
+
         trace: function (message) {
             if (this.level <= this.TRACE) {
                 this._print(message);


### PR DESCRIPTION
We're starting to use the require.js optimizer for our site as part of a wider build process.  It would be really useful if we could hide the normal progress information by default, so that error messages are more prominent.

I've written a solution that lets you specify "logLevel" in the configuration Javascript, which would handle our use case nicely.  Our code can then set a different logLevel if it's passed a "--verbose" flag.
