### PR TITLE
Add includeRequire to example.build.js

### DIFF
--- a/build/example.build.js
+++ b/build/example.build.js
@@ -192,6 +192,12 @@
             excludeShallow: [
                 "foo/bar/bot"
             ]
+        },
+
+        //This module entry will include require.js itself in the build file.
+        {
+            name: "foo/bar/bul",
+            includeRequire: true
         }
     ]
 })


### PR DESCRIPTION
This option isn't currently documented, and it wasn't initially obvious to me how to use it.

The example.build.js is linked from the website and has clarified a lot of other config issues for me :)
