### PR TITLE
Allow absolute path in Windows. ex) "C:\Documents and Settings\..."

### DIFF
--- a/dist/r-0.25.0.js
+++ b/dist/r-0.25.0.js
@@ -7370,7 +7370,7 @@ function (lang,   logger,   file,          parse,    optimize,   pragma,
      * the optimizer is not set up to do network access.
      */
     function disallowUrls(path) {
-        if (path.indexOf(':') !== -1 && path !== 'empty:') {
+        if (path.indexOf('://') !== -1 && path !== 'empty:') {
             throw new Error('Path is not supported: ' + path +
                             '\nOptimizer can only handle' +
                             ' local paths. Download the locally if necessary' +


### PR DESCRIPTION
Referring to the 7052nd line :

```
return url.indexOf("://") === -1 && url.indexOf("?") === -1 &&
    url.indexOf('empty:') !== 0;
```
