### PR TITLE
file.parent() doesn't work on Windows paths.  

### DIFF
--- a/dist/r-20110808.js
+++ b/dist/r-20110808.js
@@ -2460,9 +2460,14 @@ define('node/file', ['fs', 'path'], function (fs, path) {
         },
 
         parent: function (fileName) {
-            var parts = fileName.split('/');
-            parts.pop();
-            return parts.join('/');
+            var parts;
+            if( env === 'node' ){
+                return path.dirname( fileName );
+            } else {
+                parts = fileName.split(/[/\\]/);
+                parts.pop();
+                return parts.join('/');
+            }
         },
 
         /**


### PR DESCRIPTION
Node has a dirname method, so using that instead. 
I don't use Rhino and I couldn't find API docs so falling back to a better split.
Let windows negotiate join('/'), it works just fine.
