### PR TITLE
For namespaced builds at runtime - when the namespace already exists, do not set AMD properties

### DIFF
--- a/build/jslib/pragma.js
+++ b/build/jslib/pragma.js
@@ -55,11 +55,11 @@ define(['parse', 'logger'], function (parse, logger) {
                                     ns + " === 'undefined') {\n" +
                                     ns + ' = {};\n' +
                                     fileContents +
-                                    "\n}\n" +
+                                    "\n" +
                                     ns + ".requirejs = requirejs;" +
                                     ns + ".require = require;" +
                                     ns + ".define = define;\n" +
-                                    "}());";
+                                    "}\n}());";
                 }
 
                 //Finally, if the file wants a special wrapper because it ties


### PR DESCRIPTION
The line should be skipped when 'scrappit' (example namespace) is already on the page. As it is now, the require js setup is skipped, but this last line is not, resulting the assignment of `undefined` into the namespace's AMD properties.

```
scrappit.requirejs = requirejs;scrappit.require = require;scrappit.define = define;
```

I am assuming the theory behind this section is something like:

> If the namespace already exists, do nothing to it.

The current `if` statement setup however does the following: 

> If the namespace already exists, do not set values to require/requirejs/define, but still set those undefined properties onto the namespace.

The pull request simply places the above line within the if check for the namespace's existence.

(This might not have been caught earlier because due to hoisting there's no reference error, even though the AMD fields are defined within an `if` and used outside of it. So it just silently blanks out the namespace's fields.)

Hopefully that's a clear description.
