### PR TITLE
Allow fileExclusionRegExp to accept a string as well as a JS regexp.

### DIFF
--- a/build/jslib/build.js
+++ b/build/jslib/build.js
@@ -652,7 +652,11 @@ function (lang,   logger,   file,          parse,    optimize,   pragma,
 
         //Set file.fileExclusionRegExp if desired
         if ('fileExclusionRegExp' in config) {
-            file.exclusionRegExp = config.fileExclusionRegExp;
+            if (typeof config.fileExclusionRegExp === "string") {
+              file.exclusionRegExp = new RegExp(config.fileExclusionRegExp);
+            } else {
+              file.exclusionRegExp = config.fileExclusionRegExp;
+            }
         } else if ('dirExclusionRegExp' in config) {
             //Set file.dirExclusionRegExp if desired, this is the old
             //name for fileExclusionRegExp before 1.0.2. Support for backwards


### PR DESCRIPTION
The r.js config format is _almost_ valid JSON, except for `fileExclusionRegExp`.  This change will initialize a new `RegExp` object using a string passed in `fileExclusionRegExp`.  This is particularly useful for ease of config generation from other languages such as Ruby, where the original config can then be represented with native data structures (hash, array, strings) then emitted with JSON tooling.

Caveats: it doesn't appear that the current test harness covers fileExclusionRegExp.  Likewise, it's unclear whether the harness is well suited to testing that at this time.  Suggestions on crossing the test gap would be appreciated, otherwise I may just throw something together and kick out a pull request...
