### PR TITLE
Allow requirejs.tools.traceFiles to be executed several times within the same node session

### DIFF
--- a/build/jslib/x.js
+++ b/build/jslib/x.js
@@ -150,14 +150,18 @@ var requirejs, require, define;
         //the callback.
         callback.__requireJsBuild = true;
 
-        requirejs({
-            context: 'build'
-        },      ['build', 'logger', 'requirePatch'],
-        function (build,   logger,   requirePatch) {
+        var cb = function (build,   logger,   requirePatch) {
             //Enable the requirePatch that hooks up the tracing tools.
             requirePatch();
             callback(build, logger);
-        });
+        };
+
+        cb.__requireJsBuild = true;
+
+        requirejs({
+            context: 'build'
+        },      ['build', 'logger', 'requirePatch'],
+        cb);
     }
 
     /**


### PR DESCRIPTION
I was getting an error when calling the dependency tracer more than once. Not sure this is the right way to fix it but that seems to work.
