### PR TITLE
Adding basic tests for URLs in config paths

### DIFF
--- a/build/tests/builds.js
+++ b/build/tests/builds.js
@@ -299,6 +299,47 @@ define(['build', 'env!env/file'], function (build, file) {
     );
     doh.run();
 
+    doh.register("paths.valid",
+        [
+            function (t) {
+                try {
+                    build(["lib/paths/valid/build.js"]);
+                    t.is(nol(c("lib/paths/valid/expected.js")),
+                         nol(c("lib/paths/valid/built/main.js")));
+                }
+                finally {
+                    file.deleteFile("lib/paths/valid/built");
+                    require._buildReset();
+                }
+            }
+        ]
+    );
+    doh.run();
+
+    !function(tests) {
+        for (var i = 0; i < tests.length; ++i) {
+            var test = tests[i];
+            
+            doh.register("paths.invalid." + test,
+                [
+                    function (t) {
+                        try {
+                            build(["lib/paths/invalid/" + test + ".js"]);
+                        }
+                        catch (e) {
+                            t.t(e.message.indexOf('#pathnotsupported') >= 0);
+                        }
+                        finally {
+                            file.deleteFile("lib/paths/invalid/built");
+                            require._buildReset();
+                        }
+                    }
+                ]
+            );
+            doh.run();
+        }
+    }(["http-url", "https-url", "url-without-protocol"]);
+
     doh.register("preserveLicense",
         [
             function preserveLicense(t) {

--- a/build/tests/lib/paths/invalid/http-url.js
+++ b/build/tests/lib/paths/invalid/http-url.js
@@ -1,0 +1,6 @@
+({
+    dir: 'built',
+    paths: {
+        'failure': 'http://failure'
+    }
+})

--- a/build/tests/lib/paths/invalid/https-url.js
+++ b/build/tests/lib/paths/invalid/https-url.js
@@ -1,0 +1,6 @@
+({
+    dir: 'built',
+    paths: {
+        'failure': 'https://failure'
+    }
+})

--- a/build/tests/lib/paths/invalid/url-without-protocol.js
+++ b/build/tests/lib/paths/invalid/url-without-protocol.js
@@ -1,0 +1,6 @@
+({
+    dir: 'built',
+    paths: {
+        'failure': '//failure'
+    }
+})

--- a/build/tests/lib/paths/valid/base/base.js
+++ b/build/tests/lib/paths/valid/base/base.js
@@ -1,0 +1,1 @@
+define(function() { 'base'; });

--- a/build/tests/lib/paths/valid/base/main.js
+++ b/build/tests/lib/paths/valid/base/main.js
@@ -1,0 +1,1 @@
+require(['../paths']);

--- a/build/tests/lib/paths/valid/build.js
+++ b/build/tests/lib/paths/valid/build.js
@@ -1,0 +1,8 @@
+({
+    baseUrl: './base',
+    dir: 'built',
+    optimize: 'none',
+    modules: [{
+        name: 'main'
+    }]
+})

--- a/build/tests/lib/paths/valid/expected.js
+++ b/build/tests/lib/paths/valid/expected.js
@@ -1,0 +1,31 @@
+
+define('../here.js',[],function() { 'here'; });
+
+define('../other/other.js',[],function() { 'other'; });
+
+define('../base/base.js',[],function() { 'base'; });
+
+define('base',[],function() { 'base'; });
+
+// due to undefined behavior some modules will be defined with an extension and some without after optimization
+// due to a bug related to baseUrl './base/base[.js]' and 'base[.js]' will be treated as two separate modules, even though they are the same files
+
+define('../paths',[
+    'empty:',               // empty
+    'http://nonexistant',   // http URL
+    'https://nonexistant',  // https URL
+    'foo?dynamic=1',        // dynamic URL
+    '//nonexistant',        // URL without protocol
+    './here',               // relative path
+    './here.js',            // relative path with extension
+    './other/other',        // relative path with subdirectories
+    './other/other.js',     // relative path with subdirectories with extension
+    './base/base',          // relative path
+    './base/base.js',       // relative path with extension
+    'base.js',              // baseUrl relative path with extension
+    'base'                  // baseUrl relative path
+], function () {});
+
+require(['../paths']);
+
+define("main", function(){});

--- a/build/tests/lib/paths/valid/here.js
+++ b/build/tests/lib/paths/valid/here.js
@@ -1,0 +1,1 @@
+define(function() { 'here'; });

--- a/build/tests/lib/paths/valid/other/other.js
+++ b/build/tests/lib/paths/valid/other/other.js
@@ -1,0 +1,1 @@
+define(function() { 'other'; });

--- a/build/tests/lib/paths/valid/paths.js
+++ b/build/tests/lib/paths/valid/paths.js
@@ -1,0 +1,18 @@
+// due to undefined behavior some modules will be defined with an extension and some without after optimization
+// due to a bug related to baseUrl './base/base[.js]' and 'base[.js]' will be treated as two separate modules, even though they are the same files
+
+define([
+    'empty:',               // empty
+    'http://nonexistant',   // http URL
+    'https://nonexistant',  // https URL
+    'foo?dynamic=1',        // dynamic URL
+    '//nonexistant',        // URL without protocol
+    './here',               // relative path
+    './here.js',            // relative path with extension
+    './other/other',        // relative path with subdirectories
+    './other/other.js',     // relative path with subdirectories with extension
+    './base/base',          // relative path
+    './base/base.js',       // relative path with extension
+    'base.js',              // baseUrl relative path with extension
+    'base'                  // baseUrl relative path
+], function () {});


### PR DESCRIPTION
I added some tests which check
- whether the optimizer properly ignores URL dependencies in `define` and `require` calls
- whether the optimizer properly fails if build config has URLs in `paths` (though I'm not sure why this isn't actually allowed and the dependency simply ignored)

This pull request depends on #93 and #99.

While writing these tests I found another bug in r.js, which is why #99 is required in order to use them.
