### PR TITLE
Adding error message for appDir being set without dir

### DIFF
--- a/dist/r.js
+++ b/dist/r.js
@@ -9263,6 +9263,9 @@ function (lang,   logger,   file,          parse,    optimize,   pragma,
         //Set final output dir
         if (config.hasOwnProperty("baseUrl")) {
             if (config.appDir) {
+                if (!config.dir) {
+                    throw new Error("ERROR: 'appDir' option requires 'dir' to be set");
+                }
                 config.dirBaseUrl = build.makeAbsPath(config.originalBaseUrl, config.dir);
             } else {
                 config.dirBaseUrl = config.dir || config.baseUrl;


### PR DESCRIPTION
Added a simple error that is thrown when config.appDir is set but config.dir is falsy.

Without it, it produces the undefined/undefined error and took me damn near an hour to find out why.
