### PR TITLE
fix single file (-o out=xyz) mode

### DIFF
--- a/build/jslib/build.js
+++ b/build/jslib/build.js
@@ -286,8 +286,10 @@ function (lang,   logger,   file,          parse,    optimize,   pragma,
             //Just set up the _buildPath for the module layer.
             require(config);
             if (!config.cssIn) {
-                config.modules[0]._buildPath = typeof config.out === 'function' ?
-                                               'FUNCTION' : config.out;
+                modules = config.modules = [{
+                        name: config.main,
+                        _buildPath: typeof config.out === 'function' ?
+                                               'FUNCTION' : config.out}];
             }
         } else if (!config.cssIn) {
             //Now set up the config for require to use the build area, and calculate the


### PR DESCRIPTION
The current code breaks on single-file mode even on empty project because `modules` is undefined. This simple commit fixes it. More info is below.
#### single-file mode is broken

It's broken even with empty project:

```
$ mkdir requirejs-build
$ cd requirejs-build
$ mkdir app
$ touch app/empty.js
$ r.js -o main=empty out=out.js baseUrl=app
TypeError: Cannot read property '0' of undefined
    at Function._run (/Users/edc/scratch/requirejs-build/node_modules/requirejs/bin/r.js:14294:31)
```
#### fixed with this patch

```
$ mkdir requirejs-build
$ cd requirejs-build
$ mkdir app
$ touch app/empty.js
$ r.js -o main=empty out=out.js baseUrl=app
Tracing dependencies for: empty
Uglifying file: /Users/edc/scratch/requirejs-build/out.js

/Users/edc/scratch/requirejs-build/out.js
----------------
/Users/edc/scratch/requirejs-build/app/empty.js
```

It also works when `out` is set to a function:

```
$ echo '({main:"empty",baseUrl:"app",out:function(x){console.log(x.length)}})' > build.js
$ r.js -o build.js

Tracing dependencies for: empty
Uglifying file: FUNCTION
28

FUNCTION
----------------
/Users/edc/scratch/requirejs-build/app/empty.js
```
