### PR TITLE
Providing optimizer module output file path through writeAPI

### DIFF
--- a/build/jslib/build.js
+++ b/build/jslib/build.js
@@ -1273,7 +1273,7 @@ function (lang,   logger,   file,          parse,    optimize,   pragma,
             }
         };
         for (var j = 0; j < onBuildCompletes.length; j++) {
-            fileContents = onBuildCompletes[j](moduleName, path, completeWrite);                  
+            onBuildCompletes[j](moduleName, path, completeWrite);                  
         }
 
         //Add a require at the end to kick start module execution, if that


### PR DESCRIPTION
I've added one extra parameter to the plugin writeAPI function. This is the output filename of the module being built by the optimizer.

The explanation of my use case is below. I'd be interested to hear your thoughts on this.

I have a module called require-css. The goal is to allow module my css inclusions through requirejs.

I write components with their combined css as a require like so - 

component.js::

```
define(['css!component'], function() {
});
```

The css is a null returning require that dynamically loads css on the client. It doesn't detect when the css has displayed, but loads it and injects it into the page, returning immediately after injection.

In this case it would load 'component.css'.

For builds, I then specify module builds of the form:

```
modules: [
{
  name: 'core-components',
  create: true,
  include: ['component'],
  exclude: ['core-includes']
}
```

When building on the server, the css plugin now builds up a buffer of all the required css within a module. It drops stub css definitions into the 'core-components' module.

The next step is for it to detect the flat module name as 'core-components.js' and output its css buffer for that module at the end of the write into 'core-components.css'.

In this way, instead of having build layers of single js files, I have dual build layers of css/js combinations (when build layers have css! calls defined).

This minor writeAPI change would allow for such a css inclusion process to work. It's a modular way of writing css that makes a lot of sense to me. I'd appreciate your feedback.
