### PR TITLE
Include 'create' flag when a modules array is constructed when building one file

### DIFF
--- a/dist/r.js
+++ b/dist/r.js
@@ -14973,6 +14973,7 @@ function (lang,   logger,   file,          parse,    optimize,   pragma,
                 {
                     name: config.name,
                     out: config.out,
+                    create: config.create,
                     include: config.include,
                     exclude: config.exclude,
                     excludeShallow: config.excludeShallow,


### PR DESCRIPTION
I ran into this while trying to use a namespace with [requirejs-rails](https://github.com/jwhitley/requirejs-rails/) per [the instructions on requirejs.org](http://requirejs.org/docs/faq-advanced.html#rename). Not sure if it's appropriate generally speaking but thought it worth submitting. Feel free to decline. 
