### PR TITLE
onLayerComplete for write post-processing

### DIFF
--- a/build/jslib/build.js
+++ b/build/jslib/build.js
@@ -1191,13 +1191,10 @@ function (lang,   logger,   file,          parse,    optimize,   pragma,
         }
         //run onLayerComplete plugin hooks
         var completeWrite = function (input) {
-            if (config.onBuildWrite) {
-                fileContents = config.onBuildWrite(moduleName, path, fileContents);
-            }
             fileContents += "\n" + addSemiColon(input);
         };
         for (var j = 0; j < onLayerComplete.length; j++) {
-            onLayerComplete[j](moduleName, completeWrite);                  
+            onLayerComplete[j](module.name, completeWrite);                  
         }
         //Add a require at the end to kick start module execution, if that
         //was desired. Usually this is only specified when using small shim


### PR DESCRIPTION
I'm resubmitting the pull request as in 210 (https://github.com/jrburke/r.js/pull/210), because I've managed to generalise some of the principles behind this with some simplifications.

To summarise - the use case has come out of require-css (https://github.com/guybedford/css), which allows css requires, that when built inline the css into the build script, with automatic dynamic css injection. With a special requires parameter css can also be output into a separate file, but this is an additional use case.

The key reason for this request is that we need to post-process all of the css together. In this way, rule reductions can be made, sprites can be generated etc. If we had sporadically written css blobs inlined with the script, it would still work, but it takes up more space and limits the post-processing potential.

So I present the simplified hook - onLayerComplete, for a plugin:

``` javascript
define({
  onLayerComplete: function(moduleName, write) {
  }
});
```

The moduleName is the name of the module layer in the build. And write is as expected (without onBuildWrite hooking, as I don't think it makes sense in this context). It is very simple small implementation.

There is a very simple example folder in the require-css module. It should be relatively quick to set up and get a feel for what is going on here. It may help to understand the use case better.

Please ask any questions at all. I understand you have many time constraints, and this may take a little time, but I really think this is opens up powerful css optimization opportunities for require-js.
