### PR TITLE
Allow return false to bubble up to stop traversing

### DIFF
--- a/build/jslib/parse.js
+++ b/build/jslib/parse.js
@@ -24,13 +24,15 @@ define(['./esprima'], function (esprima) {
         }
 
         if (visitor.call(null, object) === false) {
-            return;
+            return false;
         }
         for (key in object) {
             if (object.hasOwnProperty(key)) {
                 child = object[key];
                 if (typeof child === 'object' && child !== null) {
-                    traverse(child, visitor);
+                    if (traverse(child, visitor) === false) {
+                        return false;
+                    }
                 }
             }
         }


### PR DESCRIPTION
If a visitor function uses "return false" to abort traversing the ast it only works if it's currently traversing a root-element. Deeper in the tree it will not be able to break the traversing.

This fixes issue #257.

I'm honestly not sure if this change breaks anything. It works for my project which builds flawlessly. The testsuite also passes, but I don't think the test is thorough enough.
