### PR TITLE
Allow more flexibility in config.wrap

### DIFF
--- a/build/jslib/build.js
+++ b/build/jslib/build.js
@@ -939,10 +939,26 @@ function (lang,   logger,   file,          parse,    optimize,   pragma,
                         end: '}());'
                     };
                 } else {
-                    config.wrap.start = config.wrap.start ||
-                            file.readFile(build.makeAbsPath(config.wrap.startFile, absFilePath));
-                    config.wrap.end = config.wrap.end ||
-                            file.readFile(build.makeAbsPath(config.wrap.endFile, absFilePath));
+                    var i;
+                    if (typeof config.wrap.start !== "string" && (typeof config.wrap.startFile === "string" || config.wrap.startFile instanceof Array)) {
+                        if (typeof config.wrap.startFile === "string") {
+                            config.wrap.startFile = [config.wrap.startFile];
+                        }
+                        for (i = 0; i < config.wrap.startFile.length; i ++) {
+                            config.wrap.start = config.wrap.start ? config.wrap.start + "\n" : "";
+                            config.wrap.start += file.readFile(build.makeAbsPath(config.wrap.startFile[i], absFilePath));
+                        }
+                    }
+
+                    if (typeof config.wrap.end !== "string" && (typeof config.wrap.endFile === "string" || config.wrap.endFile instanceof Array)) {
+                        if (typeof config.wrap.endFile === "string") {
+                            config.wrap.endFile = [config.wrap.endFile];
+                        }
+                        for (i = 0; i < config.wrap.endFile.length; i ++) {
+                            config.wrap.end = config.wrap.end ? config.wrap.end + "\n" : "";
+                            config.wrap.end += file.readFile(build.makeAbsPath(config.wrap.endFile[i], absFilePath));
+                        }
+                    }
                 }
             }
         } catch (wrapError) {

--- a/dist/r.js
+++ b/dist/r.js
@@ -14929,10 +14929,26 @@ function (lang,   logger,   file,          parse,    optimize,   pragma,
                         end: '}());'
                     };
                 } else {
-                    config.wrap.start = config.wrap.start ||
-                            file.readFile(build.makeAbsPath(config.wrap.startFile, absFilePath));
-                    config.wrap.end = config.wrap.end ||
-                            file.readFile(build.makeAbsPath(config.wrap.endFile, absFilePath));
+                    var i;
+                    if (typeof config.wrap.start !== "string" && (typeof config.wrap.startFile === "string" || config.wrap.startFile instanceof Array)) {
+                        if (typeof config.wrap.startFile === "string") {
+                            config.wrap.startFile = [config.wrap.startFile];
+                        }
+                        for (i = 0; i < config.wrap.startFile.length; i ++) {
+                            config.wrap.start = config.wrap.start ? config.wrap.start + "\n" : "";
+                            config.wrap.start += file.readFile(build.makeAbsPath(config.wrap.startFile[i], absFilePath));
+                        }
+                    }
+
+                    if (typeof config.wrap.end !== "string" && (typeof config.wrap.endFile === "string" || config.wrap.endFile instanceof Array)) {
+                        if (typeof config.wrap.endFile === "string") {
+                            config.wrap.endFile = [config.wrap.endFile];
+                        }
+                        for (i = 0; i < config.wrap.endFile.length; i ++) {
+                            config.wrap.end = config.wrap.end ? config.wrap.end + "\n" : "";
+                            config.wrap.end += file.readFile(build.makeAbsPath(config.wrap.endFile[i], absFilePath));
+                        }
+                    }
                 }
             }
         } catch (wrapError) {


### PR DESCRIPTION
- config.wrap.start & config.wrap.end can now be empty strings
- config.wrap.startFile & config.wrap.endFile now accept arrays.
  r.js will loop through the array from front to back and include
  the contents of each file in the array.
