### PR TITLE
Remove newlines from commonjs preamble

### DIFF
--- a/build/jslib/commonJs.js
+++ b/build/jslib/commonJs.js
@@ -82,11 +82,11 @@ define(['env!env/file', 'parse'], function (file, parse) {
 
                 if (commonJsProps.dirname || commonJsProps.filename) {
                     preamble = 'var __filename = module.uri || "", ' +
-                               '__dirname = __filename.substring(0, __filename.lastIndexOf("/") + 1);\n';
+                               '__dirname = __filename.substring(0, __filename.lastIndexOf("/") + 1);';
                 }
 
                 //Construct the wrapper boilerplate.
-                fileContents = 'define(function (require, exports, module) {\n' +
+                fileContents = 'define(function (require, exports, module) {' +
                     preamble +
                     fileContents +
                     '\n});\n';


### PR DESCRIPTION
When using r.js to convert a CommonJS module we are messing up line numbers in the generated source. There's no reason to since if we remove the newlines there's no downside and it should just work.
