### PR TITLE
Extend the fix for https://github.com/jrburke/r.js/issues/202 to prefixes

### DIFF
--- a/dist/r.js
+++ b/dist/r.js
@@ -531,6 +531,7 @@ var requirejs, require, define;
                 prefix = null,
                 parentName = parentModuleMap ? parentModuleMap.name : null,
                 originalName = name,
+                originalPrefix = prefix, 
                 isDefine = true,
                 normalizedName = '';
 
@@ -591,6 +592,7 @@ var requirejs, require, define;
                 unnormalized: !!suffix,
                 url: url,
                 originalName: originalName,
+                originalPrefix: originalPrefix,
                 isDefine: isDefine,
                 id: (prefix ?
                         prefix + '!' + normalizedName :
@@ -1030,8 +1032,7 @@ var requirejs, require, define;
             callPlugin: function () {
                 var map = this.map,
                     id = map.id,
-                    //Map already normalized the prefix.
-                    pluginMap = makeModuleMap(map.prefix);
+                    pluginMap = makeModuleMap(map.originalPrefix);
 
                 //Mark this as a dependency for this plugin, so it
                 //can be traced for cycles.


### PR DESCRIPTION
Currently when a request to load a prefix is delegated to nodeRequire it is passed the normalized version, stripping out any path prefixes.

Not sure if this is the right file to be editing, but you get the idea.
