### PR TITLE
document wait seconds in build.js example

### DIFF
--- a/build/example.build.js
+++ b/build/example.build.js
@@ -538,5 +538,12 @@
     //http://en.wikipedia.org/wiki/Conditional_comment#Conditional_comments_in_JScript
     //2) It is only useful in optimize: 'none' scenarios. The goal is to allow
     //easier built layer debugging, which goes against minification desires.
-    useSourceUrl: true
+    useSourceUrl: true,
+
+    //Defines the loading time for modules. Depending on the complexity of the
+    //dependencies and the size of the involved libraries, increasing the wait
+    //interval may be required. Default is 7 seconds. Setting the value to 0
+    //disables the waiting interval.
+    waitSeconds: 7
+
 })


### PR DESCRIPTION
While solving an issue in my own project by increasing `waitSeconds`, I found that the parameter is missing the build.js example. So, the pull request adds the parameter to the example.

I think it would also be could to mention the parameter at http://requirejs.org/docs/errors.html#timeout because when running into the timeout, the optimizer mentions this link.

Note also that the I never had the issue when using requirejs 2.0.6. But when I upgraded to 2.1.4, I directly ran into it. Is the new optimizer slower somehow? Has it become much more complex?
