### PR TITLE
fix "identifier char is a reserved word" in r.js

### DIFF
--- a/dist/r.js
+++ b/dist/r.js
@@ -13827,8 +13827,8 @@ define('source-map/source-node', function (require, exports, module) {
           }
         });
       }
-      chunk.split('').forEach(function (char) {
-        if (char === '\n') {
+      chunk.split('').forEach(function (chars) {
+        if (chars === '\n') {
           generated.line++;
           generated.column = 0;
         } else {


### PR DESCRIPTION
fix "identifier char is a reserved word" in r.js, it will make an error
for yuicompressor 2.3.6 to compress r.js
