### PR TITLE
Alternative solution to #196

### DIFF
--- a/build/jslib/node/quit.js
+++ b/build/jslib/node/quit.js
@@ -2,6 +2,22 @@
 define(function () {
     'use strict';
     return function (code) {
-        return process.exit(code);
+        var draining = 0;
+        var exit = function () {
+            if (draining === 0) {
+                process.exit(code);
+            } else {
+                draining -= 1;
+            }
+        };
+        if (process.stdout.bufferSize) {
+            draining += 1;
+            process.stdout.once('drain', exit);
+        }
+        if (process.stderr.bufferSize) {
+            draining += 1;
+            process.stderr.once('drain', exit);
+        }
+        exit();
     };
 });


### PR DESCRIPTION
Based off https://github.com/visionmedia/mocha/issues/333#issuecomment-7441955

Instead of synchronously writing to stdout/stderr wait for them to drain when exit is called.

Tested on node 0.8.7, 0.8.17, 0.10.2 on Windows 7 and it fixes problems with disappearing output when node is piped/redirected within powershell.
