### PR TITLE
Handle booleans in transform.js' objectToString

### DIFF
--- a/build/jslib/transform.js
+++ b/build/jslib/transform.js
@@ -364,7 +364,7 @@ function (esprima, parse, logger, lang) {
                 value = 'null';
             } else if (obj === undefined) {
                 value = 'undefined';
-            } else if (typeof obj === 'number') {
+            } else if (typeof obj === 'number' || typeof obj === 'boolean') {
                 value = obj;
             } else if (typeof obj === 'string') {
                 //Use double quotes in case the config may also work as JSON.


### PR DESCRIPTION
This was causing some issues with `grunt-bower-requirejs`, as it uses `modifyConfig`. The resulting config had its boolean values replaced with empty objects, `{}`.

I haven't run the unit tests over this, but it's such a trivial change that it _shouldn't_ cause any issues.
