### PR TITLE
Demo implementation to fetch files from CDNs

### DIFF
--- a/build/jslib/node/file.js
+++ b/build/jslib/node/file.js
@@ -7,7 +7,7 @@
 /*jslint plusplus: false, octal:false, strict: false */
 /*global define: false, process: false */
 
-define(['fs', 'path', 'prim'], function (fs, path, prim) {
+define(['fs', 'path', 'prim', 'http', 'url'], function (fs, path, prim, http, url) {
 
     var isWindows = process.platform === 'win32',
         windowsDriveRegExp = /^[a-zA-Z]\:\/$/,
@@ -69,7 +69,11 @@ define(['fs', 'path', 'prim'], function (fs, path, prim) {
             parts.pop();
             return parts.join('/');
         },
-
+		
+		is_url : function(path) {
+			return path.indexOf('//') === 0 || path.indexOf("http://") === 0 || path.indexOf("https://") === 0;
+		},
+		
         /**
          * Gets the absolute file path as a string, normalized
          * to using front slashes for path separators.
@@ -84,10 +88,16 @@ define(['fs', 'path', 'prim'], function (fs, path, prim) {
         },
 
         isFile: function (path) {
+        	if (this.is_url(path)) {
+        		return true;
+        	}
             return fs.statSync(path).isFile();
         },
 
         isDirectory: function (path) {
+        	if (this.is_url(path)) {
+        		return false;
+        	}
             return fs.statSync(path).isDirectory();
         },
 
@@ -226,7 +236,38 @@ define(['fs', 'path', 'prim'], function (fs, path, prim) {
         readFileAsync: function (path, encoding) {
             var d = prim();
             try {
-                d.resolve(file.readFile(path, encoding));
+            	if (this.is_url(path)) {
+            		if (path.indexOf("//") === 0) {
+            			path = "http:" + path;
+            		}
+            		var options = url.parse(path);
+            		options.method = 'GET';
+            		
+            		var r = http.request(options, function(res) {
+            			res.setEncoding(encoding);
+            			if (res.statusCode > 400) {
+            				d.reject(new Error('Status: ' + res.statusCode));
+            			}
+            			else {
+            				var text = "";
+            				res.on('data', function(chunk) {
+            					text += chunk;
+            				})
+            				.on('end', function() {
+            					console.log("Fetched " + path);
+            					d.resolve(text);
+            				});
+            			}
+            		})
+            		.on('error', function(e) {
+            			console.log("error " + e + " fetching " + path);
+            			d.reject(e);
+            		});
+            		r.end();
+            	}
+            	else {
+                	d.resolve(file.readFile(path, encoding));
+                }
             } catch (e) {
                 d.reject(e);
             }

--- a/build/jslib/requirePatch.js
+++ b/build/jslib/requirePatch.js
@@ -69,12 +69,17 @@ define([ 'env!env/file', 'pragma', 'parse', 'lang', 'logger', 'commonJs', 'prim'
          * @param {String} url
          * @returns {Boolean}
          */
-        require._isSupportedBuildUrl = function (url) {
+        require._isSupportedBuildUrl = function (url, fetchFromNetwork) {
             //Ignore URLs with protocols, hosts or question marks, means either network
             //access is needed to fetch it or it is too dynamic. Note that
             //on Windows, full paths are used for some urls, which include
             //the drive, like c:/something, so need to test for something other
             //than just a colon.
+            
+        	if (fetchFromNetwork && file.is_url(url)) {
+        		return true;
+        	}
+        	
             if (url.indexOf("://") === -1 && url.indexOf("?") === -1 &&
                     url.indexOf('empty:') !== 0 && url.indexOf('//') !== 0) {
                 return true;
@@ -178,7 +183,7 @@ define([ 'env!env/file', 'pragma', 'parse', 'lang', 'logger', 'commonJs', 'prim'
                     //Only handle urls that can be inlined, so that means avoiding some
                     //URLs like ones that require network access or may be too dynamic,
                     //like JSONP
-                    if (require._isSupportedBuildUrl(url)) {
+                    if (require._isSupportedBuildUrl(url, context.config.fetchFromNetwork)) {
                         //Adjust the URL if it was not transformed to use baseUrl.
                         url = normalizeUrlWithBase(context, moduleName, url);
 
@@ -449,7 +454,7 @@ define([ 'env!env/file', 'pragma', 'parse', 'lang', 'logger', 'commonJs', 'prim'
                     layer.modulesWithNames[id] = true;
                     layer.pathAdded[id] = true;
                 }
-            } else if (map.url && require._isSupportedBuildUrl(map.url)) {
+            } else if (map.url && require._isSupportedBuildUrl(map.url, context.config.fetchFromNetwork)) {
                 //If the url has not been added to the layer yet, and it
                 //is from an actual file that was loaded, add it now.
                 url = normalizeUrlWithBase(context, id, map.url);


### PR DESCRIPTION
I've seen this feature requested a few times around the web, and I needed it myself, so this is a partial implementation for allowing r.js to fetch files from a CDN to include in the compressed file. I'm assuming that since I only implemented it in node/file.js it'll only work on node.

Some feedback would be useful, I think one thing that would help is to add something to the optimized file that removes the entries in the paths config for cdns.

To anyone that finds this patch useful, my requirejs.config is similar to:

``` javascript
requirejs.config({
   baseUrl :'/static/js/lib',
   paths : {
      main : '../app/main',
      jquery : '//cdnjs.... url/jquery'
   },
   deps : ['main']
})
```

And my r.js build config:

``` javascript
({
    optimize: "none",
    baseUrl : "project/static/js/lib",
    out : "project/static/js/app/main-compressed.js",
    name : "main",
    mainConfigFile : "project/static/js/requireconfig.js",
    paths : {
        main : "../app/main"
    },
    fetchFromNetwork : true,
    wrap: {
        start: "(function() {",
        end: "\nrequire(['main']);}());"
    },
})
```
