### PR TITLE
Parser and forward slashes (windows)

### DIFF
--- a/build/jslib/parse.js
+++ b/build/jslib/parse.js
@@ -124,7 +124,8 @@ define(['./esprimaAdapter', 'lang'], function (esprima, lang) {
             result = '',
             moduleList = [],
             needsDefine = true,
-            astRoot = esprima.parse(fileContents);
+            astRoot = esprima.parse(fileContents),
+            forwardSlashRegexp = /\\/g; //used to replace windows style paths
 
         parse.recurse(astRoot, function (callName, config, name, deps) {
             if (!deps) {
@@ -152,7 +153,7 @@ define(['./esprimaAdapter', 'lang'], function (esprima, lang) {
         }, options);
 
         if (options.insertNeedsDefine && needsDefine) {
-            result += 'require.needsDefine("' + moduleName + '");';
+            result += 'require.needsDefine("' + moduleName.replace(forwardSlashRegexp, '\\\\') + '");';
         }
 
         if (moduleDeps.length || moduleList.length) {
@@ -171,7 +172,7 @@ define(['./esprimaAdapter', 'lang'], function (esprima, lang) {
                 }
 
                 depString = arrayToString(moduleCall.deps);
-                result += 'define("' + moduleCall.name + '",' +
+                result += 'define("' + moduleCall.name.replace(forwardSlashRegexp, '\\\\') + '",' +
                           depString + ');';
             }
             if (moduleDeps.length) {
@@ -179,7 +180,7 @@ define(['./esprimaAdapter', 'lang'], function (esprima, lang) {
                     result += '\n';
                 }
                 depString = arrayToString(moduleDeps);
-                result += 'define("' + moduleName + '",' + depString + ');';
+                result += 'define("' + moduleName.replace(forwardSlashRegexp, '\\\\') + '",' + depString + ');';
             }
         }
 

--- a/build/tests/parse.js
+++ b/build/tests/parse.js
@@ -50,6 +50,7 @@ define(['parse', 'env!env/file', 'env'], function (parse, file, env) {
                 t.is('define("good3",["one","two"]);', parse("good3", "good3", good3));
                 t.is('define("good4",["one","two"]);', parse("good4", "good4", good4));
                 t.is('define("bad1",["me"]);', parse("bad1", "bad1", bad1));
+                t.is('define("C:\\\\test\\\\good1",["one","two"]);', parse('C:\\test\\good1', "good1", good1));
                 t.is(null, parse("bad2", "bad2", bad2));
             }
         ]


### PR DESCRIPTION
Hi. I got a problem on windows platform while running on rhino.
r.js was tracing dependencies for our file and it was only finding this file itself.
I debugged r.js and found out that there was problem with paths. I passed name argument to r.js with windows style path (C:\workspace\test\file).

defQueue variable in completeLoad function (https://github.com/stforek/r.js/blob/master/dist/r.js#L1745) was containing paths without slashes:
"C: orkspace est ile"
Optimizer didn't throw any exception (and it should..).

I attached a test case.
