### PR TITLE
use the default externs when compiling code with the closure compiler.

### DIFF
--- a/build/jslib/rhino/optimize.js
+++ b/build/jslib/rhino/optimize.js
@@ -79,12 +79,12 @@ define(['logger', 'env!env/file'], function (logger, file) {
                 outBaseName, outFileNameMap, outFileNameMapContent,
                 jscomp = Packages.com.google.javascript.jscomp,
                 flags = Packages.com.google.common.flags,
-                //Fake extern
-                externSourceFile = closurefromCode("fakeextern.js", " "),
                 //Set up source input
                 jsSourceFile = closurefromCode(String(fileName), String(fileContents)),
+                sourceListArray = new java.util.ArrayList(),
                 options, option, FLAG_compilation_level, compiler,
-                Compiler = Packages.com.google.javascript.jscomp.Compiler;
+                Compiler = Packages.com.google.javascript.jscomp.Compiler,
+                CommandLineRunner = Packages.com.google.javascript.jscomp.CommandLineRunner;
 
             logger.trace("Minifying file: " + fileName);
 
@@ -115,8 +115,12 @@ define(['logger', 'env!env/file'], function (logger, file) {
             //Trigger the compiler
             Compiler.setLoggingLevel(Packages.java.util.logging.Level[config.loggingLevel || 'WARNING']);
             compiler = new Compiler();
+            
+            //fill the sourceArrrayList; we need the ArrayList because the only overload of compile 
+            //accepting the getDefaultExterns return value (a List) also wants the sources as a List
+            sourceListArray.add(jsSourceFile);
 
-            result = compiler.compile(externSourceFile, jsSourceFile, options);
+            result = compiler.compile(CommandLineRunner.getDefaultExterns(), sourceListArray, options);
             if (result.success) {
                 optimized = String(compiler.toSource());
 


### PR DESCRIPTION
this replaces pull request #505.
Here the original text:

I found [this thread](https://groups.google.com/forum/#!topic/requirejs/_JelcAq8j64) about r.js not including the default externs when compiling using the closure compiler in the ADVANCED_OPTIMIZATIONS mode. I see you were involved but, unless I'm missing something, it looks like you never added the functionality to r.js.

I created a small patch that does the trick, it's just a few lines so I hope is small enough for being pulled without me having to sign any CLA.

On a side note, the command line compiler has a --use_only_custom_externs parameter to prevent the default externs from being used. Such parameter is not available in the [CompilerOptions](http://closure-compiler.googlecode.com/svn/trunk/javadoc/com/google/javascript/jscomp/CompilerOptions.html) class so I guess it should be implemented from the outside. I preferred to avoid to add a new configuration option, let me know what you think.
