### PR TITLE
Add a configuration option to allow transforming the output file names

### DIFF
--- a/build/jslib/build.js
+++ b/build/jslib/build.js
@@ -339,6 +339,9 @@ define(function (require) {
                     modules.forEach(function (module) {
                         if (module.name) {
                             module._buildPath = buildContext.nameToUrl(module.name, null);
+                            if (typeof config.outputFileNameTransformer === 'function') {
+                                module._buildPath = config.outputFileNameTransformer(module._buildPath);
+                            }
                             if (!module.create) {
                                 file.copyFile(module._sourcePath, module._buildPath);
                             }


### PR DESCRIPTION
My current use case for this is that I need to do several builds (i.e., run the optimizer several times), one for each language so I can have, for example:
- app_en-US.js
- app_ru.js
- app_pt-PT.js
