### PR TITLE
Respect fileExclusionRegExp in initial build directory copy

### DIFF
--- a/build/jslib/build.js
+++ b/build/jslib/build.js
@@ -234,7 +234,10 @@ define(function (require) {
                 //lots of files to process.
 
                 //First copy all the baseUrl content
-                file.copyDir((config.appDir || config.baseUrl), config.dir, /\w/, true);
+                file.copyDir((config.appDir || config.baseUrl), config.dir, {
+                    'include' : /\w/,
+                    'exclude' : file.exclusionRegExp
+                }, true);
 
                 //Adjust baseUrl if config.appDir is in play, and set up build output paths.
                 buildPaths = {};


### PR DESCRIPTION
Currently the entire appDir or baseUrl directory is copied over initially. This is unnecessary, and if there are other directories or files in the appDir that are supposed to be ignored (per the fileExclusionRegExp option) there can be unwanted side-effects to having R.js muck with them.

I'm not sure if this change should be here as well: https://github.com/jrburke/r.js/blob/master/build/jslib/build.js#L274
