### PR TITLE
Rethrow error with new message to retain details

### DIFF
--- a/build/jslib/build.js
+++ b/build/jslib/build.js
@@ -196,7 +196,8 @@ define(function (require) {
                 }
             }
 
-            throw new Error(errorMsg);
+            e.message = errorMsg;
+            throw e;
         });
     };
 


### PR DESCRIPTION
It's currently not possible to inspect e.g the code attribute for ENOENT with errors thrown from rjs as a new error with only the same message is created. This used to work back in 1.x and can be useful when using rjs as a library.

Changing the message of the existing error makes my code run again.
