### PR TITLE
Fixed bug in makeRelativeFilePath() - targetPath wasn't normalized

### DIFF
--- a/build/jslib/build.js
+++ b/build/jslib/build.js
@@ -864,7 +864,7 @@ define(function (require) {
     build.makeRelativeFilePath = function (refPath, targetPath) {
         var i, dotLength, finalParts, length,
             refParts = refPath.split('/'),
-            targetParts = targetPath.split('/'),
+            targetParts = file.normalize(targetPath).split('/'),
             //Pull off file name
             targetName = targetParts.pop(),
             dotParts = [];

--- a/build/tests/buildUtils.js
+++ b/build/tests/buildUtils.js
@@ -139,6 +139,10 @@ define(['build'], function (build) {
                 t.is('../../../Applications/foo/',
                     build.makeRelativeFilePath('/Users/some/thing/',
                                            '/Applications/foo/'));
+
+                t.is('modules/player.js',
+                    build.makeRelativeFilePath('/some/other/www-built/js/app/main.js',
+                                                '/some/other/www-built/js/main/lib/../../app/modules/player.js'));
             }
         ]);
     doh.run();


### PR DESCRIPTION
`targetPath` has to be normalized before using it within `makeRelativeFilePath()`. Otherwise function gives invalid result.
