### PR TITLE
fix for optimizer adding prefix to css URLs that start with '#'

### DIFF
--- a/build/jslib/optimize.js
+++ b/build/jslib/optimize.js
@@ -43,15 +43,16 @@ function (lang,   logger,   envOptimize,        file,           parse,
 
     function fixCssUrlPaths(fileName, path, contents, cssPrefix) {
         return contents.replace(cssUrlRegExp, function (fullMatch, urlMatch) {
-            var colonIndex, parts, i,
+            var colonIndex, firstChar, parts, i,
                 fixedUrlMatch = cleanCssUrlQuotes(urlMatch);
 
             fixedUrlMatch = fixedUrlMatch.replace(lang.backSlashRegExp, "/");
 
-            //Only do the work for relative URLs. Skip things that start with / or have
+            //Only do the work for relative URLs. Skip things that start with / or #, or have
             //a protocol.
+            firstChar = fixedUrlMatch.charAt(0);
             colonIndex = fixedUrlMatch.indexOf(":");
-            if (fixedUrlMatch.charAt(0) !== "/" && (colonIndex === -1 || colonIndex > fixedUrlMatch.indexOf("/"))) {
+            if (firstChar !== "/" && firstChar !== "#" && (colonIndex === -1 || colonIndex > fixedUrlMatch.indexOf("/"))) {
                 //It is a relative URL, tack on the cssPrefix and path prefix
                 urlMatch = cssPrefix + path + fixedUrlMatch;
 


### PR DESCRIPTION
This change makes it so that css URLs paths starting with '#' are not prefixed.  The only case where I've seen this crop up is the following which apparently enables VML in IE8.

``` css
.lvml {
  behavior: url(#default#VML);
  /* ... */
}
```

One prominent library that uses this syntax is [Leaflet](https://github.com/Leaflet/Leaflet/blob/master/dist/leaflet.css).  When building a project with CSS that imports Leaflet's CSS, e.g.:

``` css
@import url("lib/leaflet.css");
```

the above statement becomes

``` css
.lvml {
  behavior: url(lib/#default#VML);
  /* ... */
}
```

in the built CSS file.
