### PR TITLE
Use package location if one is specified

### DIFF
--- a/require.js
+++ b/require.js
@@ -291,12 +291,17 @@ var requirejs, require, define;
                     trimDots(name);
 
                     //Some use of packages may use a . path to reference the
-                    //'main' module name, so normalize for that.
+                    //'main' module name, so normalize for that. Use the
+                    //package location for relative paths if one is specified.
                     pkgConfig = getOwn(config.pkgs, (pkgName = name[0]));
-                    name = name.join('/');
-                    if (pkgConfig && name === pkgName + '/' + pkgConfig.main) {
-                        name = pkgName;
+                    if (pkgConfig) {
+                        if (name.join('/') === pkgName + '/' + pkgConfig.main) {
+                            name = pkgName;
+                        } else if (pkgConfig.location) {
+                            name[0] = pkgConfig.location;
+                        }
                     }
+                    name = name.join('/');
                 } else if (name.indexOf('./') === 0) {
                     // No baseName, so this is ID is resolved relative
                     // to baseUrl, pull off the leading dot.


### PR DESCRIPTION
I ran into an issue when trying to use the package config to build a project, where the config is:

``` js
({
    baseUrl: ".",
    optimize: 'none',
    cjsTranslate: true,
    paths: {
      lodash: './node_modules/lodash/lodash'
    },
    packages: [{
      name: 'bluebird',
      location: 'node_modules/bluebird',
      main: './js/main/bluebird.js'
    }],
    name: "knex",
    out: "knex-built.js"
})
```

I was getting the error:

``` sh
Tracing dependencies for: knex
Error: ENOENT, no such file or directory '/Users/tgriesser/Github/knex/bluebird/js/main/global.js'
In module tree:
    knex
      lib/raw
        lib/common
          lib/promise
            bluebird/js/main/promise
```

In this case, it was resolving relative package paths relative to the `main` file, which wasn't using the `location` to find the correct path. So it was doing:

``` sh
/Users/tgriesser/Github/knex/bluebird/js/main/global.js
```

rather than

``` sh
/Users/tgriesser/Github/knex/node_modules/bluebird/js/main/global.js
```

This pull request adds a check to see if a location is defined and if so replaces appropriately in the package name.
