### PR TITLE
stat -> lstat

### DIFF
--- a/dist/r.js
+++ b/dist/r.js
@@ -3681,7 +3681,7 @@ define('node/file', ['fs', 'path', 'prim'], function (fs, path, prim) {
             //summary: deletes a file or directory if it exists.
             var files, i, stat;
             if (file.exists(fileName)) {
-                stat = fs.statSync(fileName);
+                stat = fs.lstatSync(fileName);
                 if (stat.isDirectory()) {
                     files = fs.readdirSync(fileName);
                     for (i = 0; i < files.length; i++) {


### PR DESCRIPTION
fixes issue where symlink directories were
reported as directories, causing fs.rmdirSync to
fail
