### PR TITLE
package.json compliance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+    "name": "requirejs",
+    "version": "2.1.10",
+    "main": "dist/r.js",
     "volo": {
         "url": "https://raw.github.com/jrburke/r.js/{version}/dist/r.js"
     }


### PR DESCRIPTION
As I understand things, a package.json should always have a name and a version at a minimum. In addition if the main resource is not index.js then a "main" property is required.

I don't understand Volo, and it may well be taking care of this business somehow (I see there's an npm module published), but this non-conforming package.json is confusing to an outsider.
