### PR TITLE
Support writing output to stdout by using out=stdout.

### DIFF
--- a/build/example.build.js
+++ b/build/example.build.js
@@ -439,6 +439,11 @@
         //to this function, sourceMapText, will be the text of the source map.
     },
 
+    //By setting "out" to "stdout", the optimized output is written to STDOUT.
+    //This can be useful for integrating r.js with other commandline tools.
+    //In order to avoid additional output "logLevel: 4" should also be used.
+    out: "stdout",
+
     //Wrap any build bundle in a start and end text specified by wrap.
     //Use this to encapsulate the module code so that define/require are
     //not globals. The end text can expose some globals from your file,

--- a/build/jslib/build.js
+++ b/build/jslib/build.js
@@ -1022,6 +1022,22 @@ define(function (require) {
             config = {},
             buildBaseConfig = makeBuildBaseConfig();
 
+        //If out=stdout, write output to STDOUT instead of a file.
+        if (cfg.out && cfg.out === 'stdout') {
+            cfg.out = function (content) {
+                var e = env.get();
+                if (e === 'rhino') {
+                    var out = new java.io.PrintStream(java.lang.System.out, true, 'UTF-8');
+                    out.println(content);
+                } else if (e === 'node') {
+                    process.stdout.setEncoding('utf8');
+                    process.stdout.write(content);
+                } else {
+                    console.log(content);
+                }
+            }
+        }
+
         //Make sure all paths are relative to current directory.
         absFilePath = file.absPath('.');
         build.makeAbsConfig(cfg, absFilePath);


### PR DESCRIPTION
For integration with other (command line) tools it would be nice to write output of r.js directly to **stdout** instead of a file (issue #474). In order to do this one can set _out=stdout_, e.g.:

``` bash
node r.js -o name=main baseUrl=app out=stdout logLevel=4
```

To avoid additional output, one must disable logging with `logLevel=4`.
This method works best with node and rhino, for other environments `console.log` is used.
