### PR TITLE
SourceUrl option not working for modules with defineInfos.length === 0

### DIFF
--- a/build/jslib/transform.js
+++ b/build/jslib/transform.js
@@ -31,7 +31,16 @@ function (esprima, parse, logger, lang) {
                 foundAnon,
                 scanCount = 0,
                 scanReset = false,
-                defineInfos = [];
+                defineInfos = [],
+                applySourceUrl = function (contents) {
+                    if (options.useSourceUrl) {
+                        contents = 'eval("' + lang.jsEscape(contents) +
+                            '\\n//# sourceURL=' + (path.indexOf('/') === 0 ? '' : '/') +
+                            path +
+                            '");\n';
+                    }
+                    return contents;
+                };
 
             try {
                 astRoot = esprima.parse(contents, {
@@ -197,8 +206,9 @@ function (esprima, parse, logger, lang) {
                 }
             });
 
+
             if (!defineInfos.length) {
-                return contents;
+                return applySourceUrl(contents);
             }
 
             //Reverse the matches, need to start from the bottom of
@@ -270,14 +280,7 @@ function (esprima, parse, logger, lang) {
 
             contents = contentLines.join('\n');
 
-            if (options.useSourceUrl) {
-                contents = 'eval("' + lang.jsEscape(contents) +
-                    '\\n//# sourceURL=' + (path.indexOf('/') === 0 ? '' : '/') +
-                    path +
-                    '");\n';
-            }
-
-            return contents;
+            return applySourceUrl(contents);
         },
 
         /**


### PR DESCRIPTION
Hi James,

I'm using the sourceUrl option on my dev environment and realized it was not working for some files (named modules for example but not only).

Here's the reason why : 
The sourceUrl magic happens at the very end of the transform.toTransport function. But higher in the code, if ever the module has a defineInfos.length === 0, the "contents" variable is returned without being wrapped in the eval statement.

My pull request fixes that issue.
