### PR TITLE
Don't detect Trireme as Rhino

### DIFF
--- a/build/jslib/env.js
+++ b/build/jslib/env.js
@@ -16,10 +16,10 @@
     var pathRegExp = /(\/|^)env\/|\{env\}/,
         env = 'unknown';
 
-    if (typeof Packages !== 'undefined') {
-        env = 'rhino';
-    } else if (typeof process !== 'undefined' && process.versions && !!process.versions.node) {
+    if (typeof process !== 'undefined' && process.versions && !!process.versions.node) {
         env = 'node';
+    } else if (typeof Packages !== 'undefined') {
+        env = 'rhino';
     } else if ((typeof navigator !== 'undefined' && typeof document !== 'undefined') ||
             (typeof importScripts !== 'undefined' && typeof self !== 'undefined')) {
         env = 'browser';

--- a/build/jslib/x.js
+++ b/build/jslib/x.js
@@ -51,36 +51,6 @@ var requirejs, require, define, xpcUtil;
             return false;
         };
 
-    } else if (typeof Packages !== 'undefined') {
-        env = 'rhino';
-
-        fileName = args[0];
-
-        if (fileName && fileName.indexOf('-') === 0) {
-            commandOption = fileName.substring(1);
-            fileName = args[1];
-        }
-
-        //Set up execution context.
-        rhinoContext = Packages.org.mozilla.javascript.ContextFactory.getGlobal().enterContext();
-
-        exec = function (string, name) {
-            return rhinoContext.evaluateString(this, string, name, 0, null);
-        };
-
-        exists = function (fileName) {
-            return (new java.io.File(fileName)).exists();
-        };
-
-        //Define a console.log for easier logging. Don't
-        //get fancy though.
-        if (typeof console === 'undefined') {
-            console = {
-                log: function () {
-                    print.apply(undefined, arguments);
-                }
-            };
-        }
     } else if (typeof process !== 'undefined' && process.versions && !!process.versions.node) {
         env = 'node';
 
@@ -120,6 +90,36 @@ var requirejs, require, define, xpcUtil;
         if (fileName && fileName.indexOf('-') === 0) {
             commandOption = fileName.substring(1);
             fileName = process.argv[3];
+        }
+    } else if (typeof Packages !== 'undefined') {
+        env = 'rhino';
+
+        fileName = args[0];
+
+        if (fileName && fileName.indexOf('-') === 0) {
+            commandOption = fileName.substring(1);
+            fileName = args[1];
+        }
+
+        //Set up execution context.
+        rhinoContext = Packages.org.mozilla.javascript.ContextFactory.getGlobal().enterContext();
+
+        exec = function (string, name) {
+            return rhinoContext.evaluateString(this, string, name, 0, null);
+        };
+
+        exists = function (fileName) {
+            return (new java.io.File(fileName)).exists();
+        };
+
+        //Define a console.log for easier logging. Don't
+        //get fancy though.
+        if (typeof console === 'undefined') {
+            console = {
+                log: function () {
+                    print.apply(undefined, arguments);
+                }
+            };
         }
     } else if (typeof Components !== 'undefined' && Components.classes && Components.interfaces) {
         env = 'xpconnect';


### PR DESCRIPTION
Trireme is an emulation of node.js that runs on Rhino:

https://github.com/apigee/trireme

It provides the node API, and should be treated by r.js as node. However, r.js detects Rhino by checking for the existence of Packages before checking for node. This then promptly fails a few lines of code later, here:

``` javascript
fileName = args[0];

if (fileName && fileName.indexOf('-') === 0) {
    commandOption = fileName.substring(1);
    fileName = args[1];
}
```

Because for some reason (possibly a bug in Trireme?), although args[0] returned an object, that object doesn't have an indexOf method. At any rate, the correct way to get the command line arguments in trireme is to use the node api, process.argv.

Presumably this can be solved by trying to detect node before trying to detect rhino, and I assume that should be fine because I don't think anyone's going to ever try to emulate Rhino on node. If someone confirms that changing the detection order is an appropriate solution, I'll happily submit a pull request.  I've tested, if you swap them around, r.js does detect node, and it works.
