### PR TITLE
Class name update to work with latest closure compiler

### DIFF
--- a/build/jslib/rhino/optimize.js
+++ b/build/jslib/rhino/optimize.js
@@ -44,7 +44,7 @@ define(['logger', 'env!env/file'], function (logger, file) {
 
     //Bind to Closure compiler, but if it is not available, do not sweat it.
     try {
-        JSSourceFilefromCode = java.lang.Class.forName('com.google.javascript.jscomp.JSSourceFile').getMethod('fromCode', [java.lang.String, java.lang.String]);
+        JSSourceFilefromCode = java.lang.Class.forName('com.google.javascript.jscomp.SourceFile').getMethod('fromCode', [java.lang.String, java.lang.String]);
     } catch (e) {}
 
     //Helper for closure compiler, because of weird Java-JavaScript interactions.


### PR DESCRIPTION
class com.google.javascript.jscomp.JSSourceFile was removed a long time ago from Closure Compiler. Features was moved to base class: SourceFile
