### PR TITLE
JS source file fetching Java class order reverted

### DIFF
--- a/build/jslib/rhino/optimize.js
+++ b/build/jslib/rhino/optimize.js
@@ -44,12 +44,12 @@ define(['logger', 'env!env/file'], function (logger, file) {
 
     //Bind to Closure compiler, but if it is not available, do not sweat it.
     try {
-        // Try for newer closure compiler that needs Java 7+
-        JSSourceFilefromCode = java.lang.Class.forName('com.google.javascript.jscomp.SourceFile').getMethod('fromCode', [java.lang.String, java.lang.String]);
-    } catch (e) {
         // Try older closure compiler that worked on Java 6
+        JSSourceFilefromCode = java.lang.Class.forName('com.google.javascript.jscomp.JSSourceFile').getMethod('fromCode', [java.lang.String, java.lang.String]);
+    } catch (e) {
         try {
-            JSSourceFilefromCode = java.lang.Class.forName('com.google.javascript.jscomp.JSSourceFile').getMethod('fromCode', [java.lang.String, java.lang.String]);
+            // Try for newer closure compiler that needs Java 7+
+            JSSourceFilefromCode = java.lang.Class.forName('com.google.javascript.jscomp.SourceFile').getMethod('fromCode', [java.lang.String, java.lang.String]);
         } catch (e) {}
     }
 


### PR DESCRIPTION
The SourceFile class exists always, so it will success on old Java, but run incorrectly. I've reversed order: first seek for old one(JSSourceFile) - if it is present use it (will work on old only). If it fails use SourceFile (will work on new)
