### PR TITLE
Support Regular Expressions and Arrays in cssImportIgnore

### DIFF
--- a/build/example.build.js
+++ b/build/example.build.js
@@ -214,8 +214,11 @@
 
     //If optimizeCss is in use, a list of files to ignore for the @import
     //inlining. The value of this option should be a string of comma separated
-    //CSS file names to ignore (like 'a.css,b.css'. The file names should match
-    //whatever strings are used in the @import calls.
+    //CSS file names to ignore (like 'a.css,b.css'). The file names should match
+    //whatever strings are used in the @import calls. Alternatively, the ignore
+    //list may be specified as a single regular expression or as an array of
+    //regular expressions or strings. In the latter case, the strings must be
+    //exact matches for the file names rather than comma separated lists.
     cssImportIgnore: null,
 
     //cssIn is typically used as a command line option. It can be used

--- a/build/jslib/optimize.js
+++ b/build/jslib/optimize.js
@@ -81,7 +81,7 @@ function (lang,   logger,   envOptimize,        file,           parse,
      * Inlines nested stylesheets that have @import calls in them.
      * @param {String} fileName the file name
      * @param {String} fileContents the file contents
-     * @param {String} cssImportIgnore comma delimited string of files to ignore
+     * @param {String} cssImportIgnore comma delimited string of files to ignore or array of regexp/string
      * @param {String} cssPrefix string to be prefixed before relative URLs
      * @param {Object} included an object used to track the files already imported
      */
@@ -100,7 +100,7 @@ function (lang,   logger,   envOptimize,        file,           parse,
         fileContents = fileContents.replace(cssCommentImportRegExp, '');
 
         //Make sure we have a delimited ignore list to make matching faster
-        if (cssImportIgnore && cssImportIgnore.charAt(cssImportIgnore.length - 1) !== ",") {
+        if (cssImportIgnore && typeof cssImportIgnore === "string" && cssImportIgnore.charAt(cssImportIgnore.length - 1) !== ",") {
             cssImportIgnore += ",";
         }
 
@@ -114,8 +114,26 @@ function (lang,   logger,   envOptimize,        file,           parse,
             importFileName = cleanCssUrlQuotes(importFileName);
 
             //Ignore the file import if it is part of an ignore list.
-            if (cssImportIgnore && cssImportIgnore.indexOf(importFileName + ",") !== -1) {
-                return fullMatch;
+            if (cssImportIgnore) {
+                //Strings may be comma-separated lists.
+                if (typeof cssImportIgnore === "string" && cssImportIgnore.indexOf(importFileName + ",") !== -1) {
+                    return fullMatch;
+                }
+                //Regex are checked for simple matches.
+                if (cssImportIgnore instanceof RegExp && cssImportIgnore.test(importFileName)) {
+                    return fullMatch;
+                }
+                //Arrays requiring checking individual elements.
+                if (Array.isArray(cssImportIgnore)) {
+                    cssImportIgnore.forEach(function(expr){
+                        if (typeof expr === "string" && expr === importFileName) {
+                            return fullMatch;
+                        }
+                        if (expr instanceof RegExp && expr.test(importFileName)) {
+                            return fullMatch;
+                        }
+                    })
+                }
             }
 
             //Make sure we have a unix path for the rest of the operation.


### PR DESCRIPTION
CSS file URLs may legitimately include commas. The recommended CSS for Google Web Fonts, for example, might look like:

```
@import url('//fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,400,300,600,700&subset=latin,cyrillic-ext,latin-ext,greek-ext');
```

This PR allows `cssImportIgnore` to support regular expressions and an array of strings or regular expressions in addition to the current format of a single "comma separated list."

> Note: Contributor License Agreement for stephen@sathomas.me is on file.
