### PR TITLE
Relax namespace regexps

### DIFF
--- a/build/jslib/pragma.js
+++ b/build/jslib/pragma.js
@@ -36,12 +36,12 @@ define(['parse', 'logger'], function (parse, logger) {
         configRegExp: /(^|[^\.])(requirejs|require)(\.config)\s*\(/g,
         nsWrapRegExp: /\/\*requirejs namespace: true \*\//,
         apiDefRegExp: /var requirejs,\s*require,\s*define;/,
-        defineCheckRegExp: /typeof\s+define\s*===\s*["']function["']\s*&&\s*define\s*\.\s*amd/g,
-        defineStringCheckRegExp: /typeof\s+define\s*===\s*["']function["']\s*&&\s*define\s*\[\s*["']amd["']\s*\]/g,
+        defineCheckRegExp: /typeof\s+define\s*===?\s*["']function["']\s*&&\s*define\s*\.\s*amd/g,
+        defineStringCheckRegExp: /typeof\s+define\s*===?\s*["']function["']\s*&&\s*define\s*\[\s*["']amd["']\s*\]/g,
         defineTypeFirstCheckRegExp: /\s*["']function["']\s*==(=?)\s*typeof\s+define\s*&&\s*define\s*\.\s*amd/g,
-        defineJQueryRegExp: /typeof\s+define\s*===\s*["']function["']\s*&&\s*define\s*\.\s*amd\s*&&\s*define\s*\.\s*amd\s*\.\s*jQuery/g,
+        defineJQueryRegExp: /typeof\s+define\s*===?\s*["']function["']\s*&&\s*define\s*\.\s*amd\s*&&\s*define\s*\.\s*amd\s*\.\s*jQuery/g,
         defineHasRegExp: /typeof\s+define\s*==(=)?\s*['"]function['"]\s*&&\s*typeof\s+define\.amd\s*==(=)?\s*['"]object['"]\s*&&\s*define\.amd/g,
-        defineTernaryRegExp: /typeof\s+define\s*===\s*['"]function["']\s*&&\s*define\s*\.\s*amd\s*\?\s*define/,
+        defineTernaryRegExp: /typeof\s+define\s*===?\s*['"]function["']\s*&&\s*define\s*\.\s*amd\s*\?\s*define/,
         amdefineRegExp: /if\s*\(\s*typeof define\s*\!==\s*'function'\s*\)\s*\{\s*[^\{\}]+amdefine[^\{\}]+\}/g,
 
         removeStrict: function (contents, config) {


### PR DESCRIPTION
The regular expressions used in namespace rewrites don't properly recognize defines that look like:

``` javascript
if (typeof define == 'function' && define.amd) {
  define(...);
}
```

... because it currently expects strict equivalence, like this:

``` javascript
if (typeof define === 'function' && define.amd) {
  define(...);
}
```

While I agree the latter is preferable, if there are no downsides to supporting the former as well, that would help the "namespace-ability" of many modules out there that use the former syntax (where they don't notice any issues if namespacing isn't used).

That said, I wonder if namespacing is better done via a method similar to that described in http://requirejs.org/docs/faq-advanced.html#rename, where instead of attempting to regular expression match and rewrite `define` calls, we wrap the entire file in something like:

``` javascript
(function (define, require, requirejs) {
  // file contents here
}(NS.define, NS.require, NS.requirejs));
```
