### PR TITLE
Add support for a new onReadFileError optimizer hook

### DIFF
--- a/build/jslib/build.js
+++ b/build/jslib/build.js
@@ -43,7 +43,7 @@ define(function (require) {
     //Caching function for performance. Attached to
     //require so it can be reused in requirePatch.js. _cachedRawText
     //set up by requirePatch.js
-    require._cacheReadAsync = function (path, encoding) {
+    require._cacheReadAsync = function (path, encoding, moduleName, context) {
         var d;
 
         if (lang.hasProp(require._cachedRawText, path)) {
@@ -51,7 +51,7 @@ define(function (require) {
             d.resolve(require._cachedRawText[path]);
             return d.promise;
         } else {
-            return file.readFileAsync(path, encoding).then(function (text) {
+            return file.readFileAsync(path, encoding, moduleName, context).then(function (text) {
                 require._cachedRawText[path] = text;
                 return text;
             });

--- a/build/jslib/node/file.js
+++ b/build/jslib/node/file.js
@@ -204,7 +204,7 @@ define(['fs', 'path', 'prim'], function (fs, path, prim) {
         /**
          * Reads a *text* file.
          */
-        readFile: function (/*String*/path, /*String?*/encoding) {
+        readFile: function (/*String*/path, /*String?*/encoding, /*String?*/moduleName, /*String?*/context) {
             if (encoding === 'utf-8') {
                 encoding = 'utf8';
             }
@@ -212,7 +212,17 @@ define(['fs', 'path', 'prim'], function (fs, path, prim) {
                 encoding = 'utf8';
             }
 
-            var text = fs.readFileSync(path, encoding);
+            var text;
+
+            try {
+                text = fs.readFileSync(path, encoding);
+            } catch(e) {
+                if(context && context.config && context.config.onReadFileError) {
+                    text = context.config.onReadFileError(moduleName, path);
+                } else {
+                    throw e;
+                }
+            }
 
             //Hmm, would not expect to get A BOM, but it seems to happen,
             //remove it just in case.
@@ -223,10 +233,10 @@ define(['fs', 'path', 'prim'], function (fs, path, prim) {
             return text;
         },
 
-        readFileAsync: function (path, encoding) {
+        readFileAsync: function (path, encoding, moduleName, context) {
             var d = prim();
             try {
-                d.resolve(file.readFile(path, encoding));
+                d.resolve(file.readFile(path, encoding, moduleName, context));
             } catch (e) {
                 d.reject(e);
             }

--- a/build/jslib/requirePatch.js
+++ b/build/jslib/requirePatch.js
@@ -239,7 +239,7 @@ define([ 'env!env/file', 'pragma', 'parse', 'lang', 'logger', 'commonJs', 'prim'
                             } else {
                                 //Load the file contents, process for conditionals, then
                                 //evaluate it.
-                                return require._cacheReadAsync(url).then(function (text) {
+                                return require._cacheReadAsync(url, null, moduleName, context).then(function (text) {
                                     contents = text;
 
                                     if (context.config.cjsTranslate &&


### PR DESCRIPTION
**What**: A new `onReadFileError` optimizer hook that is called whenever the Require.js optimizer cannot find a file dependency.

**Why**: This will allow developers to add custom support for fallback file lookup algorithms (e.g. node.js)

**Example:**

``` javascript
onReadFileError: function (moduleName, path) {
  var fs = require('fs');
  // If a file is not found with the Require.js configurations,
  // use the node.js file lookup algorithm
  return fs.readFileSync(require.resolve(moduleName), 'utf8');
}
```

**Questions**: I could not get the Require.js tests to complete successfully **with or without** this change.  Could you take a look and let me know what else I need to do to integrate this PR?

Thanks!
