### PR TITLE
Allow use of sourceRoot option for source map generation

### DIFF
--- a/build/jslib/build.js
+++ b/build/jslib/build.js
@@ -1730,6 +1730,7 @@ define(function (require) {
                                    module._buildPath.replace(sourceMapBase, '');
                 sourceMapGenerator = new SourceMapGenerator.SourceMapGenerator({
                     file: fileForSourceMap
+                    sourceRoot: config.sourceRoot
                 });
             }
 

--- a/build/jslib/build.js
+++ b/build/jslib/build.js
@@ -1729,7 +1729,7 @@ define(function (require) {
                                    (module.name || module.include[0] || 'FUNCTION') + '.build.js' :
                                    module._buildPath.replace(sourceMapBase, '');
                 sourceMapGenerator = new SourceMapGenerator.SourceMapGenerator({
-                    file: fileForSourceMap
+                    file: fileForSourceMap,
                     sourceRoot: config.sourceRoot
                 });
             }


### PR DESCRIPTION
Hi,

I'm using grunt-contrib-requirejs to build my app. The issue is that the build directory sits next to the app directory. This generates sources that are relative to the `baseUrl`, which causes issues when viewing the folder structure in Chrome.

I don't know if this pull request covers all the bases, but it works for now and I'd be happy to fill in the gaps where needed to get the `sourceRoot` option to work.