### PR TITLE
Update useStrict regexp so that it doesn't strip anything but "use strict";

### DIFF
--- a/build/jslib/pragma.js
+++ b/build/jslib/pragma.js
@@ -31,7 +31,7 @@ define(['parse', 'logger'], function (parse, logger) {
 
     var pragma = {
         conditionalRegExp: /(exclude|include)Start\s*\(\s*["'](\w+)["']\s*,(.*)\)/,
-        useStrictRegExp: /['"]use strict['"];/g,
+        useStrictRegExp: /^\s*['"]use strict['"];$/gm,
         hasRegExp: /has\s*\(\s*['"]([^'"]+)['"]\s*\)/g,
         configRegExp: /(^|[^\.])(requirejs|require)(\.config)\s*\(/g,
         nsWrapRegExp: /\/\*requirejs namespace: true \*\//,


### PR DESCRIPTION
Made useStrict option only strip "use strict"; if it appears on a single and has nothing but whitespace before it.
