### PR TITLE
Fix source maps when using wrap

### DIFF
--- a/build/jslib/build.js
+++ b/build/jslib/build.js
@@ -1735,7 +1735,7 @@ define(function (require) {
             }
 
             //Write the built module to disk, and build up the build output.
-            fileContents = "";
+            fileContents = config.wrap ? config.wrap.start : "";
             return prim.serial(layer.buildFilePaths.map(function (path) {
                 return function () {
                     var lineCount,
@@ -1974,7 +1974,7 @@ define(function (require) {
         }).then(function () {
             return {
                 text: config.wrap ?
-                        config.wrap.start + fileContents + config.wrap.end :
+                        fileContents + config.wrap.end :
                         fileContents,
                 buildText: buildFileContents,
                 sourceMap: sourceMapGenerator ?


### PR DESCRIPTION
This fixes the issue where if you use the `wrap` option to append stuff to the beginning of the outputted module the line numbers in the source map are wrong, making them completely useless.

I would like to write a test for this, however I couldn't even get them to run on master. I ran `node dist.js` and then I get the following output when trying to run the tests.

```sh
jonbretman@Jons-MBP:~/git/r.js/build/tests$ node ../../r.js all.js 
1 tests to run in 1 groups
------------------------------------------------------------
GROUP "convert" has 1 test to run
------------------------------------------------------------
GROUP "parseConfig" has 1 test to run
------------------------------------------------------------
GROUP "parseRequire" has 1 test to run
------------------------------------------------------------
GROUP "parseDefineCall" has 1 test to run
------------------------------------------------------------
GROUP "parseFindNestedDependencies" has 1 test to run
------------------------------------------------------------
GROUP "parseHasRequire" has 1 test to run
------------------------------------------------------------
GROUP "parseUsesAmdOrRequireJs" has 1 test to run
------------------------------------------------------------
GROUP "parseUsesCommonJs" has 1 test to run
------------------------------------------------------------
GROUP "parseFindCjsDependencies" has 1 test to run
------------------------------------------------------------
GROUP "parseLicenseComments" has 1 test to run
------------------------------------------------------------
GROUP "pragmaNamespace" has 1 test to run
------------------------------------------------------------
GROUP "transformModifyConfig" has 1 test to run
------------------------------------------------------------
GROUP "toTransport" has 1 test to run
bad6 has more than one anonymous define. May be a built file from another build system like, Ender. Skipping normalization.
------------------------------------------------------------
GROUP "makeRelativeFilePath" has 1 test to run

fs.js:438
  return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
                 ^
Error: ENOENT, no such file or directory 'builds/text.js'
    at Object.fs.openSync (fs.js:438:18)
    at Object.fs.readFileSync (fs.js:289:15)
    at Object.file.readFile (/Users/jonbretman/git/r.js/build/jslib/node/file.js:215:27)
    at c (/Users/jonbretman/git/r.js/build/tests/builds.js:11:21)
    at /Users/jonbretman/git/r.js/build/tests/builds.js:34:31
    at Object.context.execCb (/Users/jonbretman/git/r.js/r.js:1897:33)
    at Object.Module.check (/Users/jonbretman/git/r.js/r.js:1113:51)
    at Object.<anonymous> (/Users/jonbretman/git/r.js/r.js:1360:34)
    at /Users/jonbretman/git/r.js/r.js:371:23
    at /Users/jonbretman/git/r.js/r.js:1403:21

```