### PR TITLE
Add config.onJsProcessComplete option

### DIFF
--- a/build/jslib/optimize.js
+++ b/build/jslib/optimize.js
@@ -228,6 +228,10 @@ function (lang,   logger,   envOptimize,        file,           parse,
             //Apply pragmas/namespace renaming
             fileContents = pragma.process(fileName, fileContents, config, 'OnSave', pluginCollector);
 
+            if (config.onJsProcessComplete) {
+                fileContents = config.onJsProcessComplete(fileContents, fileName);
+            }
+
             //Optimize the JS files if asked.
             if (optimizerName && optimizerName !== 'none') {
                 optFunc = envOptimize[optimizerName] || optimize.optimizers[optimizerName];


### PR DESCRIPTION
## New `config.onJsProcessComplete` option

The purpose of this new build config callback is to give access to a JS bundle content right before it would be optimized with UglifyJS or Closure (or not).

The `config.onModuleBundleComplete` callback is called when a module is finished being assembled, but this happens before `pragma.process` is called, which modifies the code even more (conditional comments, use strict removal, etc). Some libraries that depend upon this callback simply to access the code before it is optimized can run into issues when items processed in `pragma.process` happen after their callback. `config.onJsProcessComplete` is called immediately after `pragmas.process` and immediately before optimization.

This will also allow for easy integration for any JavaScript optimizer not officially supported by r.js, including custom or legacy versions of officially supported optimizers.
## Example Usages

```
// AMDClean
onJsProcessComplete: function(fileContents, fileName) {
    return amdclean.clean({ code: fileContents });
}

// Custom version of UglifyJS
onJsProcessComplete: function(fileContents, fileName) {
    return CustomUglifyJS.minify(fileContents, { fromString: true });
}
```
