### PR TITLE
Preserve license comments if using uglify2

### DIFF
--- a/build/jslib/optimize.js
+++ b/build/jslib/optimize.js
@@ -450,6 +450,15 @@ function (lang,   logger,   envOptimize,        file,           parse,
 
                 config = config || {};
 
+                uconfig.output = {
+                    comments = function(node, comment) {
+                        //More or less same functionality as closure compiler,
+                        //would be set by uglify.js' command line tool if --comments is set
+                        //see https://github.com/mishoo/UglifyJS2/blob/master/bin/uglifyjs
+                        return comment.type === "comment2" && /@preserve|@license|@cc_on/i.test(comment.value);
+                    };
+                };
+
                 lang.mixin(uconfig, config, true);
 
                 uconfig.fromString = true;


### PR DESCRIPTION
http://requirejs.org/docs/errors.html#sourcemapcomments says:

> If you want to preserve some license comments, you can manually modify the license comments in the JS source to use the JSDoc-style @license comment. See "Annotating JavaScript for the Closure Compiler" for more information. That same format works for UglifyJS2.

I found this is **not** true for r.js running node.js & uglify2. It is only true if the uglify2 command line tool sets an output option. This is of course not the case for r.js invocation of uglify2. Hence I replicated the functionality (see source code comment).

Note that this comment:

    /** @license (c) Foo Bar 2015 */

When using r.js with Rhino and Closure, will turn into:

    /* (c) Foo Bar 2015 */

but will stay the same when using r.js with node.js and Uglify2:

    /** @license (c) Foo Bar 2015 */

But this is just how the tools work...

Please merge :)

Cheers,
Kosta