### PR TITLE
Corrects the path for requireLib in http test.

### DIFF
--- a/build/tests/http/httpBuild.js
+++ b/build/tests/http/httpBuild.js
@@ -20,7 +20,7 @@ config = {
         //in use, change this path to that file. One possibility
         //could be the one at:
         //https://github.com/ajaxorg/ace/blob/master/build_support/mini_require.js
-        requireLib: '../../../../../requirejs/require'
+        requireLib: '../../../../require'
     },
     //Uncomment this line if uglify minification is not wanted.
     //optimize: 'none',


### PR DESCRIPTION
	Earlier value assumes the folder where project
	is cloned should be named requirejs. Thus changed the path
	to go one level less back for require.js path.