### PR TITLE
add onbuildwriteJS to provide a hook for easy parsing of the entire output

### DIFF
--- a/build/jslib/build.js
+++ b/build/jslib/build.js
@@ -1898,6 +1898,10 @@ define(function (require) {
                         //for some space separation between files in case ASI issues
                         //for concatenation would cause an error otherwise.
                         singleContents += '\n';
+        
+                        if (config.onBuildWriteJS) {
+                          singleContents = config.onBuildWriteJS(moduleName, path, singleContents);
+                        }
 
                         //Add to the source map
                         if (sourceMapGenerator) {
@@ -1958,7 +1962,11 @@ define(function (require) {
                             path = module._buildPath;
                         }
                         builder.onLayerEnd(function (input) {
-                            fileContents += "\n" + addSemiColon(input, config);
+                          var output = addSemiColon(input, config);
+                          if (config.onBuildWriteJS) {
+                            config.onBuildWriteJS(layer.prefix, layer.name, output);
+                          }
+                            fileContents += "\n" + output;
                         }, {
                             name: module.name,
                             path: path


### PR DESCRIPTION
as a request from @jrburke on https://github.com/jrburke/r.js/issues/783, here is an example PR of what customization we added for our internal streaming build tool

the goal is to write a hook such that another tool can examine each dependency after it is built by rjs. upon examination, a sourceMap is built (most pieces actually include a sourceMap which is followed, consumed and sourcesContent is preserved). all the sourceMaps are then combined into one giant sourcemap and all the output is also combined into the final build.rjs (i could just use the output passed into `out()`, but wasn't sure if this was gauranteed to always be the same)

we had to add two hooks, because at first, we found our build.js to be missing essential components. these came about because of our use of require.css and require.i18n plugins. with the additional hook, we were able to get it working (we also had to generate on the fly sourcemaps, but that works too)

however, this is still hacky. what we really wanted was a column number and a line number for every piece that is getting added into our final build.js

the reason the hack works is because 

1. the column is always zero, because r.js adds new lines
2. i can count (and track) the total length of each piece, to properly predict what line number in the final build.js i'm at

thus, i'm able to build a working sourcemap. i could just parse what i see in `out`, but this was a lot easier (once i figured out where to put the hooks).