### PR TITLE
Try `Java.type().class` for Nashorn (fixes #822)

### DIFF
--- a/build/jslib/rhino/optimize.js
+++ b/build/jslib/rhino/optimize.js
@@ -50,7 +50,13 @@ define(['logger', 'env!env/file'], function (logger, file) {
         try {
             // Try for newer closure compiler that needs Java 7+
             JSSourceFilefromCode = java.lang.Class.forName('com.google.javascript.jscomp.SourceFile').getMethod('fromCode', [java.lang.String, java.lang.String]);
-        } catch (e) {}
+        } catch (e) {
+            try {
+                // Try Nashorn style
+                var stringClass = Java.type("java.lang.String").class;
+                JSSourceFilefromCode = Java.type("com.google.javascript.jscomp.SourceFile").class.getMethod("fromCode", [stringClass, stringClass]);
+            } catch (e) {}
+        }
     }
 
     //Helper for closure compiler, because of weird Java-JavaScript interactions.


### PR DESCRIPTION
Adds a case that tries the `Java.type()` API for Nashorn compatibility.