### PR TITLE
Cover more namespace rewrite use cases

### DIFF
--- a/build/jslib/pragma.js
+++ b/build/jslib/pragma.js
@@ -42,6 +42,8 @@ define(['parse', 'logger'], function (parse, logger) {
         defineJQueryRegExp: /typeof\s+define\s*===?\s*["']function["']\s*&&\s*define\s*\.\s*amd\s*&&\s*define\s*\.\s*amd\s*\.\s*jQuery/g,
         defineHasRegExp: /typeof\s+define\s*==(=)?\s*['"]function['"]\s*&&\s*typeof\s+define\.amd\s*==(=)?\s*['"]object['"]\s*&&\s*define\.amd/g,
         defineTernaryRegExp: /typeof\s+define\s*===?\s*['"]function["']\s*&&\s*define\s*\.\s*amd\s*\?\s*define/,
+        defineExistsRegExp: /\s+typeof\s+define\s*!==?\s*['"]undefined["']\s*/,
+        defineExistsAndAmdRegExp: /typeof\s+define\s*!==?\s*['"]undefined["']\s*&&\s*define\s*\.\s*amd\s*/,
         amdefineRegExp: /if\s*\(\s*typeof define\s*\!==\s*'function'\s*\)\s*\{\s*[^\{\}]+amdefine[^\{\}]+\}/g,
 
         removeStrict: function (contents, config) {
@@ -68,6 +70,10 @@ define(['parse', 'logger'], function (parse, logger) {
                 fileContents = fileContents.replace(pragma.defineHasRegExp,
                                                     "typeof " + ns + ".define === 'function' && typeof " + ns + ".define.amd === 'object' && " + ns + ".define.amd");
 
+                //Namespace async.js define use:
+                fileContents = fileContents.replace(pragma.defineExistsAndAmdRegExp,
+                                                    "typeof " + ns + ".define !== 'undefined' && " + ns + ".define.amd");
+
                 //Namespace define checks.
                 //Do these ones last, since they are a subset of the more specific
                 //checks above.
@@ -77,6 +83,8 @@ define(['parse', 'logger'], function (parse, logger) {
                                                     "typeof " + ns + ".define === 'function' && " + ns + ".define['amd']");
                 fileContents = fileContents.replace(pragma.defineTypeFirstCheckRegExp,
                                                     "'function' === typeof " + ns + ".define && " + ns + ".define.amd");
+                fileContents = fileContents.replace(pragma.defineExistsRegExp,
+                                                    "typeof " + ns + ".define !== 'undefined'");
 
                 //Check for require.js with the require/define definitions
                 if (pragma.apiDefRegExp.test(fileContents) &&

--- a/build/tests/pragma.js
+++ b/build/tests/pragma.js
@@ -18,6 +18,8 @@ define(['pragma', 'env!env/file'], function (pragma, file) {
                 t.is(c('pragma/good1Expected.js'), pragma.namespace(c('pragma/good1.js'), 'foo'));
                 t.is(c('pragma/good2Expected.js'), pragma.namespace(c('pragma/good2.js'), 'foo'));
                 t.is(c('pragma/good3Expected.js'), pragma.namespace(c('pragma/good3.js'), 'foo'));
+                t.is(c('pragma/good4Expected.js'), pragma.namespace(c('pragma/good4.js'), 'foo'));
+                t.is(c('pragma/good5Expected.js'), pragma.namespace(c('pragma/good5.js'), 'foo'));
             }
         ]);
     doh.run();

--- a/build/tests/pragma/good4.js
+++ b/build/tests/pragma/good4.js
@@ -1,0 +1,9 @@
+if ( typeof module === "object" && module && typeof module.exports === "object" ) {
+    module.exports = jQuery;
+}
+
+if ( typeof define !== "undefined" ) {
+    define([], function () {
+        return jQuery;
+    });
+}

--- a/build/tests/pragma/good4Expected.js
+++ b/build/tests/pragma/good4Expected.js
@@ -1,0 +1,9 @@
+if ( typeof module === "object" && module && typeof module.exports === "object" ) {
+    module.exports = jQuery;
+}
+
+if (typeof foo.define !== 'undefined') {
+    foo.define([], function () {
+        return jQuery;
+    });
+}

--- a/build/tests/pragma/good5.js
+++ b/build/tests/pragma/good5.js
@@ -1,0 +1,8 @@
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = jQuery;
+}
+else if (typeof define !== 'undefined' && define.amd) {
+    define([], function () {
+        return jQuery;
+    });
+}

--- a/build/tests/pragma/good5Expected.js
+++ b/build/tests/pragma/good5Expected.js
@@ -1,0 +1,8 @@
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = jQuery;
+}
+else if (typeof foo.define !== 'undefined' && foo.define.amd) {
+    foo.define([], function () {
+        return jQuery;
+    });
+}


### PR DESCRIPTION
I have found at least 2 libraries that were breaking the namespacing, leading to "Mismatch" errors - namely [async](https://github.com/caolan/async) and [MicroEvent](https://github.com/dezoxel/microevent.js).

They don't check for `define === 'function'` but `define !== 'undefined'`. This PR takes this use case into account so that those `define`s are namespaced properly too.

(I have signed the CLA, under Shariff Inayat)