### PR TITLE
Adding namespace extra params

### DIFF
--- a/build/example.build.js
+++ b/build/example.build.js
@@ -301,6 +301,9 @@
     //complete example.
     namespace: 'foo',
 
+    // Allows to pass extra code to the namespace wrapper function.
+    namespaceWrapLocals: 'var require = { skipDataMain: true } ;'
+
     //Skip processing for pragmas.
     skipPragmas: false,
 

--- a/build/jslib/build.js
+++ b/build/jslib/build.js
@@ -1834,7 +1834,7 @@ define(function (require) {
                                 }
 
                                 if (namespace) {
-                                    currContents = pragma.namespace(currContents, namespace);
+                                    currContents = pragma.namespace(currContents, config);
                                 }
 
                                 currContents = build.toTransport(namespace, moduleName, path, currContents, layer, {

--- a/build/jslib/pragma.js
+++ b/build/jslib/pragma.js
@@ -50,7 +50,9 @@ define(['parse', 'logger'], function (parse, logger) {
             return config.useStrict ? contents : contents.replace(pragma.useStrictRegExp, '$1');
         },
 
-        namespace: function (fileContents, ns, onLifecycleName) {
+        namespace: function (fileContents, config, onLifecycleName) {
+            var ns = config.namespace,
+                namespaceWrapLocals = config.namespaceWrapLocals ? config.namespaceWrapLocals + "\n" : '';
             if (ns) {
                 //Namespace require/define calls
                 fileContents = fileContents.replace(pragma.configRegExp, '$1' + ns + '.$2$3(');
@@ -93,6 +95,7 @@ define(['parse', 'logger'], function (parse, logger) {
                     //to contain the API globals.
                     fileContents = "var " + ns + ";(function () { if (!" + ns + " || !" + ns + ".requirejs) {\n" +
                                     "if (!" + ns + ") { " + ns + ' = {}; } else { require = ' + ns + '; }\n' +
+                                    namespaceWrapLocals +
                                     fileContents +
                                     "\n" +
                                     ns + ".requirejs = requirejs;" +
@@ -262,7 +265,7 @@ define(['parse', 'logger'], function (parse, logger) {
 
             //Do namespacing
             if (onLifecycleName === 'OnSave' && config.namespace) {
-                fileContents = pragma.namespace(fileContents, config.namespace, onLifecycleName);
+                fileContents = pragma.namespace(fileContents, config, onLifecycleName);
             }
 
 


### PR DESCRIPTION
Would be nice to have an option to pass extra parameters to the namespace wrapper function.
This is only actual for config with namespaces, as here we can't use existing 'wrap' function which is a parent level wrapper, with it's own locals and without ability to change lower level locals like 'var requirejs, require, define'.
Should allow to pass config like 'var require = { skipDataMain: true } ; ', details here: https://github.com/jrburke/requirejs/issues/876