### PR TITLE
Move `vm.runInThisContext` to require.exec

### DIFF
--- a/build/jslib/node.js
+++ b/build/jslib/node.js
@@ -105,7 +105,7 @@
     req.makeNodeWrapper = function (contents) {
         return '(function (require, requirejs, define) { ' +
                 contents +
-                '\n}(requirejsVars.require, requirejsVars.requirejs, requirejsVars.define));';
+                '\n}(global.requirejsVars.require, global.requirejsVars.requirejs, global.requirejsVars.define));';
     };
 
     req.load = function (context, moduleName, url) {
@@ -120,9 +120,8 @@
         if (exists(url)) {
             contents = fs.readFileSync(url, 'utf8');
 
-            contents = req.makeNodeWrapper(contents);
             try {
-                vm.runInThisContext(contents, fs.realpathSync(url));
+                req.exec(contents, fs.realpathSync(url));
             } catch (e) {
                 err = new Error('Evaluating ' + url + ' as module "' +
                                 moduleName + '" failed with error: ' + e);
@@ -170,9 +169,8 @@
     };
 
     //Override to provide the function wrapper for define/require.
-    req.exec = function (text) {
-        /*jslint evil: true */
+    req.exec = function (text, realPath) {
         text = req.makeNodeWrapper(text);
-        return eval(text);
+        return vm.runInThisContext(text, realPath);
     };
 }());


### PR DESCRIPTION
In split contexts, like NW.js', `vm.runInThisContext` evaluates modules in the wrong context.  And, due to its location in the code, this behavior is impossible to override.

This commit moves the call to `require.exec`, where it's overridable, and changes `require.makeNodeWrapper` to use `global.requirejsVars` so it doesn't reference a non-existent object when run in NW.js' context.

With this change require can be used in NW.js when exec is overridden like this (although there's a bug with vm in NW.js at the moment so eval has to be used instead):

    var vm = require("vm"),
        context = vm.createContext(window);

    requirejs.exec = function(text, realPath) {
        text = requirejs.makeNodeWrapper(text);

        return vm.runInContext(text, context, realPath);
    };