### PR TITLE
[doc] clarify wrapShim requirement

### DIFF
--- a/build/example.build.js
+++ b/build/example.build.js
@@ -86,6 +86,7 @@
     //ready. By wrapping those shimmed dependencies, this can be avoided, but
     //it could introduce other errors if those shimmed dependencies use the
     //global scope in weird ways, so it is not the default behavior to wrap.
+    //To use shim wrapping skipModuleInsertion needs to be false.
     //More notes in http://requirejs.org/docs/api.html#config-shim
     wrapShim: false,
 


### PR DESCRIPTION
Personally, I had `skipModuleInsertion` set to true for a reason that I can't remember and I forgot all about it. It took some r.js code reading to determine that that was causing `wrapShim` to not work.

Maybe a warning can also be emitted? Or perhaps the entire relationship be changed such that `wrapShim: true` + `skipModuleInsertion: true` means that _only_ shimmed modules are wrapped and have `define()` code inserted for them.