### PR TITLE
Fixes requirejs/requirejs#1854, pollution

### DIFF
--- a/dist/r.js
+++ b/dist/r.js
@@ -1,5 +1,5 @@
 /**
- * @license r.js 2.3.6 Copyright jQuery Foundation and other contributors.
+ * @license r.js 2.3.6+ Tue, 16 Jul 2024 05:19:14 GMT Copyright jQuery Foundation and other contributors.
  * Released under MIT license, http://github.com/requirejs/r.js/LICENSE
  */
 
@@ -19,7 +19,7 @@ var requirejs, require, define, xpcUtil;
 (function (console, args, readFileFunc) {
     var fileName, env, fs, vm, path, exec, rhinoContext, dir, nodeRequire,
         nodeDefine, exists, reqMain, loadedOptimizedLib, existsForNode, Cc, Ci,
-        version = '2.3.6',
+        version = '2.3.6 Tue, 16 Jul 2024 05:19:14 GMT',
         jsSuffixRegExp = /\.js$/,
         commandOption = '',
         useLibLoaded = {},
@@ -282,7 +282,8 @@ var requirejs, require, define, xpcUtil;
         contexts = {},
         cfg = {},
         globalDefQueue = [],
-        useInteractive = false;
+        useInteractive = false,
+        disallowedProps = ['__proto__', 'constructor'];
 
     //Could match something like ')//comment', do not lose the prefix to comment.
     function commentReplace(match, singlePrefix) {
@@ -343,7 +344,7 @@ var requirejs, require, define, xpcUtil;
     function eachProp(obj, func) {
         var prop;
         for (prop in obj) {
-            if (hasProp(obj, prop)) {
+            if (hasProp(obj, prop) && disallowedProps.indexOf(prop) == -1) {
                 if (func(obj[prop], prop)) {
                     break;
                 }

--- a/require.js
+++ b/require.js
@@ -33,7 +33,8 @@ var requirejs, require, define;
         contexts = {},
         cfg = {},
         globalDefQueue = [],
-        useInteractive = false;
+        useInteractive = false,
+        disallowedProps = ['__proto__', 'constructor'];
 
     //Could match something like ')//comment', do not lose the prefix to comment.
     function commentReplace(match, singlePrefix) {
@@ -94,7 +95,7 @@ var requirejs, require, define;
     function eachProp(obj, func) {
         var prop;
         for (prop in obj) {
-            if (hasProp(obj, prop)) {
+            if (hasProp(obj, prop) && disallowedProps.indexOf(prop) == -1) {
                 if (func(obj[prop], prop)) {
                     break;
                 }


### PR DESCRIPTION
Same fix as https://github.com/requirejs/requirejs/pull/1856, but if you download the `dist/r.js` script from this branch, you can run it in node via `var requirejs = require('./r.js')` to confirm that it works as expected in a node script.